### PR TITLE
Fix rest-client module loading on atom > 1.0

### DIFF
--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -1,4 +1,4 @@
-{$, ScrollView} = require 'atom'
+{$, ScrollView} = require 'atom-space-pen-views'
 querystring = require 'querystring'
 request = require 'request'
 fs = require 'fs'

--- a/lib/rest-client.coffee
+++ b/lib/rest-client.coffee
@@ -12,8 +12,8 @@ atom.deserializers.add(deserializer)
 
 module.exports =
   activate: ->
-    atom.workspace.registerOpener (filePath) ->
+    atom.workspace.addOpener (filePath) ->
       createRestClientView(uri: restClientUri) if filePath is restClientUri
 
-    atom.workspaceView.command 'rest-client:show', ->
-      atom.workspaceView.open(restClientUri)
+    atom.commands.add 'atom-workspace', 'rest-client:show', ->
+      atom.workspace.open(restClientUri)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "restful",
     "http-request"
   ],
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "A simple REST client for your favorite editor",
   "repository": "https://github.com/ddavison/rest-client",
   "license": "MIT",
@@ -16,6 +16,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
+    "atom-space-pen-views": "^2.0.3",
     "request": "*"
   }
 }


### PR DESCRIPTION
This will fix rest-client package load on atom > 1.0 and make it work.