### PR TITLE
Json result format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: objective-c
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
+script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+
+git:
+  depth: 10

--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -16,6 +16,7 @@ methods = [
 CURRENT_METHOD = 'GET'
 DEFAULT_RESULT = 'No data yet...'
 DEFAULT_NORESPONSE = 'NO RESPONSE'
+TAB_JSON_SPACES = 4
 
 response = '' # global object for the response.
 
@@ -200,7 +201,7 @@ class RestClientView extends ScrollView
             $(rest_form.status).removeClass('text-success')
             $(rest_form.status).addClass('text-error')
             $(rest_form.status).text(response.statusCode + " " +response.statusMessage)
-        $(rest_form.result).text(body)
+        $(rest_form.result).text(@processResult(body))
         @hideLoading()
       else
         $(rest_form.status).removeClass('text-success')
@@ -209,6 +210,19 @@ class RestClientView extends ScrollView
         $(rest_form.result).text(error)
         @hideLoading()
     )
+
+  isJson: (body) ->
+    try
+      JSON.parse(body)
+      true
+    catch error
+      false
+
+  processResult: (body) ->
+    if @isJson(body)
+      JSON.stringify(JSON.parse(body), undefined, TAB_JSON_SPACES)
+    else
+      body
 
 
   # Returns an object that can be retrieved when package is activated

--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -13,7 +13,9 @@ methods = [
   'options'
 ]
 
-current_method = 'GET'
+CURRENT_METHOD = 'GET'
+DEFAULT_RESULT = 'No data yet...'
+DEFAULT_NORESPONSE = 'NO RESPONSE'
 
 response = '' # global object for the response.
 
@@ -96,7 +98,7 @@ class RestClientView extends ScrollView
           @span class: "#{rest_form.status.split('.')[1]}"
 
           @span class: "#{rest_form.loading.split('.')[1]} loading loading-spinner-small inline-block", style: 'display: none;'
-          @pre class: "native-key-bindings #{rest_form.result.split('.')[1]}", 'No data yet..'
+          @pre class: "native-key-bindings #{rest_form.result.split('.')[1]}", #{DEFAULT_RESULT}
           @div class: "text-info lnk #{rest_form.open_in_editor.split('.')[1]}", 'Open in separate editor'
 
   initialize: ->
@@ -105,7 +107,7 @@ class RestClientView extends ScrollView
         for m in methods
           $("#{rest_form.method}-#{m}").removeClass('selected')
         $(this).addClass('selected')
-        current_method = $(this).html()
+        CURRENT_METHOD = $(this).html()
 
     @on 'click', rest_form.clear_btn, => @clearForm()
     @on 'click', rest_form.send_btn,  => @sendRequest()
@@ -122,8 +124,8 @@ class RestClientView extends ScrollView
     )(this)
 
   openInEditor: ->
-    if $(rest_form.result).text() != 'No data yet..'
-      file_name = "#{current_method} - #{$(rest_form.url).val()}"
+  if $(rest_form.result).text() != DEFAULT_RESULT
+      file_name = "#{CURRENT_METHOD} - #{$(rest_form.url).val()}"
       file_name = file_name.replace(/https?:\/\//, '')
       file_name = file_name.replace(/\//g, '')
 
@@ -152,7 +154,7 @@ class RestClientView extends ScrollView
     $(rest_form.url).val("")
     $(rest_form.headers).val("")
     $(rest_form.payload).val("")
-    $(rest_form.result).text('No data yet..')
+    $(rest_form.result).text(DEFAULT_RESULT)
     $(rest_form.status).text("")
 
   getHeaders: ->
@@ -173,7 +175,7 @@ class RestClientView extends ScrollView
     request_options =
       url: $(rest_form.url).val()
       headers: this.getHeaders()
-      method: current_method,
+      method: CURRENT_METHOD,
       body: ""
 
 
@@ -193,7 +195,7 @@ class RestClientView extends ScrollView
           when 200,201
             $(rest_form.status).removeClass('text-error')
             $(rest_form.status).addClass('text-success')
-            $(rest_form.status).text(response.statusCode + " " +response.statusMessage)
+            $(rest_form.status).text(response.statusCode + " " + response.statusMessage)
           else
             $(rest_form.status).removeClass('text-success')
             $(rest_form.status).addClass('text-error')
@@ -203,7 +205,7 @@ class RestClientView extends ScrollView
       else
         $(rest_form.status).removeClass('text-success')
         $(rest_form.status).addClass('text-error')
-        $(rest_form.status).text('NO RESPONSE')
+        $(rest_form.status).text(DEFAULT_NORESPONSE)
         $(rest_form.result).text(error)
         @hideLoading()
     )

--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -99,7 +99,7 @@ class RestClientView extends ScrollView
           @span class: "#{rest_form.status.split('.')[1]}"
 
           @span class: "#{rest_form.loading.split('.')[1]} loading loading-spinner-small inline-block", style: 'display: none;'
-          @pre class: "native-key-bindings #{rest_form.result.split('.')[1]}", #{DEFAULT_RESULT}
+          @pre class: "native-key-bindings #{rest_form.result.split('.')[1]}", "#{DEFAULT_RESULT}"
           @div class: "text-info lnk #{rest_form.open_in_editor.split('.')[1]}", 'Open in separate editor'
 
   initialize: ->

--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -125,7 +125,8 @@ class RestClientView extends ScrollView
     )(this)
 
   openInEditor: ->
-  if $(rest_form.result).text() != DEFAULT_RESULT
+  textResult = $(rest_form.result).text()
+  if [DEFAULT_RESULT, ""].indexOf(textResult) == -1
       file_name = "#{CURRENT_METHOD} - #{$(rest_form.url).val()}"
       file_name = file_name.replace(/https?:\/\//, '')
       file_name = file_name.replace(/\//g, '')
@@ -223,7 +224,6 @@ class RestClientView extends ScrollView
       JSON.stringify(JSON.parse(body), undefined, TAB_JSON_SPACES)
     else
       body
-
 
   # Returns an object that can be retrieved when package is activated
   serialize: ->

--- a/spec/rest-client-view-spec.coffee
+++ b/spec/rest-client-view-spec.coffee
@@ -1,0 +1,24 @@
+RestClientView = require '../lib/rest-client-view'
+
+describe "RestClientView test", ->
+  [restClient] = []
+
+  beforeEach ->
+    restClient = new RestClientView()
+
+  describe "View", ->
+    it "the view is loaded", ->
+      expect(restClient.find('.rest-client-send')).toExist()
+
+  describe "Json", ->
+    it "body is not json", ->
+      expect(restClient.isJson("<html></html>")).toBe(false)
+
+    it "body is json", ->
+      expect(restClient.isJson('{"hello": "world"}')).toBe(true)
+
+    it "process result is not json", ->
+      expect(restClient.processResult('<html></html>')).toEqual('<html></html>')
+
+    it "process result is json", ->
+      expect(restClient.processResult('{"hello": "world"}')).toEqual('{\n    "hello": "world"\n}')


### PR DESCRIPTION
This is related to #10 

![screen shot 2015-11-04 at 11 50 15](https://cloud.githubusercontent.com/assets/488556/10936187/6cee4938-82eb-11e5-807c-daac78aa7029.png)

The format is good now, but the syntax highlighting is a bit trickier if trying to use Atom internal system, although I almost have It. I am using the grammar tokenizer for highlighting, but I am trying to get a method from Atom API to pass the tokens to html, It doesn't seem is there anymore, or I need to read more code. Now I have:

```coffeescript
grammar = atom.grammars.grammarForScopeName('source.json')
tokenizedLines = grammar.tokenizeLines(@processResult(body), undefined, 4))
```

I'll continue working on It.

I also refactored some constants, and I think all the json related code should go in a different file, I'll get into that.