### PR TITLE
Allow requests to use non-strict SSL.

### DIFF
--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -93,7 +93,7 @@ class RestClientView extends ScrollView
           @strong 'User-Agent'
           @input class: "field #{rest_form.user_agent.split('.')[1]}", value: 'atom-rest-client'
           @string 'Strict SSL'
-          @inplut type: 'checkbox', class: "field #{rest_form.strict_ssl.split('.')[1]}", checked: true
+          @input type: 'checkbox', class: "field #{rest_form.strict_ssl.split('.')[1]}", checked: true
 
         # Payload
         @div class: 'rest-client-payload-container', =>

--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -33,6 +33,7 @@ rest_form =
   result: '.rest-client-result',
   status: '.rest-client-status',
   user_agent: '.rest-client-user-agent',
+  strict_ssl: '.rest-client-strict-ssl',
   open_in_editor: '.rest-client-open-in-editor'
   loading: '.rest-client-loading-icon'
   request_link: '.rest-client-request-link'
@@ -91,6 +92,8 @@ class RestClientView extends ScrollView
           @textarea class: "field #{rest_form.headers.split('.')[1]}", rows: 7
           @strong 'User-Agent'
           @input class: "field #{rest_form.user_agent.split('.')[1]}", value: 'atom-rest-client'
+          @string 'Strict SSL'
+          @inplut type: 'checkbox', class: "field #{rest_form.strict_ssl.split('.')[1]}", checked: true
 
         # Payload
         @div class: 'rest-client-payload-container', =>
@@ -246,6 +249,7 @@ class RestClientView extends ScrollView
       url: $(rest_form.url).val()
       headers: this.getHeaders()
       method: current_method,
+      strictSSL: $(rest_form.strict_ssl).is(':checked'),
       body: @getRequestBody()
 
   onResponse: (error, response, body) =>


### PR DESCRIPTION
Some of our internal APIs in development are using self-signed certs
and we need to relax the 'strictSSL' requirement.

The value is "on" by default:
<img width="320" alt="screen shot 2016-04-08 at 12 27 42 pm" src="https://cloud.githubusercontent.com/assets/1002112/14392490/2f98af30-fd87-11e5-8dc5-84c7dcdb04ef.png">

which can give you this response:
<img width="320" alt="screen shot 2016-04-08 at 12 27 50 pm" src="https://cloud.githubusercontent.com/assets/1002112/14392509/486f5c48-fd87-11e5-8c00-a035c11337f9.png">

When unchecked:
<img width="320" alt="screen shot 2016-04-08 at 12 28 07 pm" src="https://cloud.githubusercontent.com/assets/1002112/14392516/4ffc82ba-fd87-11e5-99f1-95001d15ec82.png">

you'll now get:
<img width="238" alt="screen shot 2016-04-08 at 12 28 14 pm" src="https://cloud.githubusercontent.com/assets/1002112/14392522/589101d0-fd87-11e5-94a6-b7192a275b47.png">
