### PR TITLE
Toggle "Headers" and "Payload" sections

### DIFF
--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -184,6 +184,9 @@ class RestClientView extends ScrollView
     @on 'click', rest_form.result_link, => @toggleResult(rest_form.result)
     @on 'click', rest_form.result_headers_link, => @toggleResult(rest_form.result_headers)
 
+    @on 'click', rest_form.headers_header, => @toggleSection(rest_form.headers_body)
+    @on 'click', rest_form.payload_header, => @toggleSection(rest_form.payload_body)
+
     $('body').on 'click', rest_form.request_link, @loadRequest
     $('body').on 'click', rest_form.request_link_remove, @removeSavedRequest
 
@@ -340,6 +343,9 @@ class RestClientView extends ScrollView
     $target = $(target)
     $target.siblings('pre').hide()
     $target.show()
+
+  toggleSection: (target) ->
+    $(target).toggle()
 
   addRequestsInView: (target, requests) ->
     if not requests?

--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -28,8 +28,10 @@ rest_form =
   method_other_field: '.rest-client-method-other-field',
   headers: '.rest-client-headers',
   headers_header: '.rest-client-headers-header',
+  headers_body: '.rest-client-headers-body',
   payload: '.rest-client-payload',
   payload_header: '.rest-client-payload-header',
+  payload_body: '.rest-client-payload-body',
   encode_payload: '.rest-client-encodepayload',
   decode_payload: '.rest-client-decodepayload',
   clear_btn: '.rest-client-clear',
@@ -94,27 +96,29 @@ class RestClientView extends ScrollView
         @div class: 'rest-client-headers-container', =>
           @h5 class: "#{rest_form.headers_header.split('.')[1]}", 'Headers'
 
-          @div class: 'btn-group btn-group-lg', =>
-            @button class: 'btn selected', 'Raw'
+          @div class: "#{rest_form.headers_body.split('.')[1]}", =>
+            @div class: 'btn-group btn-group-lg', =>
+              @button class: 'btn selected', 'Raw'
 
-          @textarea class: "field #{rest_form.headers.split('.')[1]}", rows: 7
-          @strong 'Strict SSL'
-          @input type: 'checkbox', class: "field #{rest_form.strict_ssl.split('.')[1]}", checked: true
+            @textarea class: "field #{rest_form.headers.split('.')[1]}", rows: 7
+            @strong 'Strict SSL'
+            @input type: 'checkbox', class: "field #{rest_form.strict_ssl.split('.')[1]}", checked: true
 
-          @strong null, "Proxy server"
-          @input type: 'text', class: "field #{rest_form.proxy_server.split('.')[1]}"
+            @strong null, "Proxy server"
+            @input type: 'text', class: "field #{rest_form.proxy_server.split('.')[1]}"
 
         # Payload
         @div class: 'rest-client-payload-container', =>
           @h5 class: "#{rest_form.payload_header.split('.')[1]}", 'Payload'
 
-          @div class: "text-info lnk float-right #{rest_form.decode_payload.split('.')[1]}", 'Decode payload '
-          @div class: "buffer float-right", '|'
-          @div class: "text-info lnk float-right #{rest_form.encode_payload.split('.')[1]}", 'Encode payload'
-          @div class: 'btn-group btn-group-lg', =>
-            @button class: 'btn selected', 'Raw'
+          @div class: "#{rest_form.payload_body.split('.')[1]}", =>
+            @div class: "text-info lnk float-right #{rest_form.decode_payload.split('.')[1]}", 'Decode payload '
+            @div class: "buffer float-right", '|'
+            @div class: "text-info lnk float-right #{rest_form.encode_payload.split('.')[1]}", 'Encode payload'
+            @div class: 'btn-group btn-group-lg', =>
+              @button class: 'btn selected', 'Raw'
 
-          @textarea class: "field #{rest_form.payload.split('.')[1]}", rows: 7
+            @textarea class: "field #{rest_form.payload.split('.')[1]}", rows: 7
 
         # Result
         @div class: 'tool-panel panel-bottom padded', =>

--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -345,6 +345,14 @@ class RestClientView extends ScrollView
     $target.show()
 
   toggleSection: (target) ->
+    header = $(target).parent().children('h5')
+    headerText = header.text()
+
+    if headerText.indexOf('…') < 0
+      header.text("#{headerText} …")
+    else
+      header.text("#{headerText.slice(0, headerText.length - 2)}")
+
     $(target).toggle()
 
   addRequestsInView: (target, requests) ->

--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -27,7 +27,9 @@ rest_form =
   method: '.rest-client-method',
   method_other_field: '.rest-client-method-other-field',
   headers: '.rest-client-headers',
+  headers_header: '.rest-client-headers-header',
   payload: '.rest-client-payload',
+  payload_header: '.rest-client-payload-header',
   encode_payload: '.rest-client-encodepayload',
   decode_payload: '.rest-client-decodepayload',
   clear_btn: '.rest-client-clear',
@@ -90,7 +92,7 @@ class RestClientView extends ScrollView
 
         # Headers
         @div class: 'rest-client-headers-container', =>
-          @h5 'Headers'
+          @h5 class: "#{rest_form.headers_header.split('.')[1]}", 'Headers'
 
           @div class: 'btn-group btn-group-lg', =>
             @button class: 'btn selected', 'Raw'
@@ -104,7 +106,7 @@ class RestClientView extends ScrollView
 
         # Payload
         @div class: 'rest-client-payload-container', =>
-          @h5 'Payload'
+          @h5 class: "#{rest_form.payload_header.split('.')[1]}", 'Payload'
 
           @div class: "text-info lnk float-right #{rest_form.decode_payload.split('.')[1]}", 'Decode payload '
           @div class: "buffer float-right", '|'


### PR DESCRIPTION
The "Headers" and "Payload" text can be clicked to hide the bodies of the respective sections.  For example, clicking "Headers" will change the text to "Headers ..." and hide all related elements.  This can be useful for people who want more visibility in the Result area but don't use the Headers and/or Payload sections.