### PR TITLE
Collapsing Sections

### DIFF
--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -90,7 +90,7 @@ class RestClientView extends ScrollView
 
         # Headers
         @div class: 'rest-client-headers-container', =>
-          @div class: 'rest-client-headers-header', =>
+          @div class: 'rest-client-header rest-client-headers-header', =>
             @h5 class: 'header-expanded', 'Headers'
 
           @div class: 'rest-client-headers-body', =>
@@ -106,7 +106,7 @@ class RestClientView extends ScrollView
 
         # Payload
         @div class: 'rest-client-payload-container', =>
-          @div class: 'rest-client-payload-header', =>
+          @div class: 'rest-client-header rest-client-payload-header', =>
             @h5 class: 'header-expanded', 'Payload'
 
           @div class: 'rest-client-payload-body', =>

--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -27,11 +27,7 @@ rest_form =
   method: '.rest-client-method',
   method_other_field: '.rest-client-method-other-field',
   headers: '.rest-client-headers',
-  headers_header: '.rest-client-headers-header',
-  headers_body: '.rest-client-headers-body',
   payload: '.rest-client-payload',
-  payload_header: '.rest-client-payload-header',
-  payload_body: '.rest-client-payload-body',
   encode_payload: '.rest-client-encodepayload',
   decode_payload: '.rest-client-decodepayload',
   clear_btn: '.rest-client-clear',
@@ -94,31 +90,29 @@ class RestClientView extends ScrollView
 
         # Headers
         @div class: 'rest-client-headers-container', =>
-          @h5 class: "#{rest_form.headers_header.split('.')[1]}", 'Headers'
+          @h5 'Headers'
 
-          @div class: "#{rest_form.headers_body.split('.')[1]}", =>
-            @div class: 'btn-group btn-group-lg', =>
-              @button class: 'btn selected', 'Raw'
+          @div class: 'btn-group btn-group-lg', =>
+            @button class: 'btn selected', 'Raw'
 
-            @textarea class: "field #{rest_form.headers.split('.')[1]}", rows: 7
-            @strong 'Strict SSL'
-            @input type: 'checkbox', class: "field #{rest_form.strict_ssl.split('.')[1]}", checked: true
+          @textarea class: "field #{rest_form.headers.split('.')[1]}", rows: 7
+          @strong 'Strict SSL'
+          @input type: 'checkbox', class: "field #{rest_form.strict_ssl.split('.')[1]}", checked: true
 
-            @strong null, "Proxy server"
-            @input type: 'text', class: "field #{rest_form.proxy_server.split('.')[1]}"
+          @strong null, "Proxy server"
+          @input type: 'text', class: "field #{rest_form.proxy_server.split('.')[1]}"
 
         # Payload
         @div class: 'rest-client-payload-container', =>
-          @h5 class: "#{rest_form.payload_header.split('.')[1]}", 'Payload'
+          @h5 'Payload'
 
-          @div class: "#{rest_form.payload_body.split('.')[1]}", =>
-            @div class: "text-info lnk float-right #{rest_form.decode_payload.split('.')[1]}", 'Decode payload '
-            @div class: "buffer float-right", '|'
-            @div class: "text-info lnk float-right #{rest_form.encode_payload.split('.')[1]}", 'Encode payload'
-            @div class: 'btn-group btn-group-lg', =>
-              @button class: 'btn selected', 'Raw'
+          @div class: "text-info lnk float-right #{rest_form.decode_payload.split('.')[1]}", 'Decode payload '
+          @div class: "buffer float-right", '|'
+          @div class: "text-info lnk float-right #{rest_form.encode_payload.split('.')[1]}", 'Encode payload'
+          @div class: 'btn-group btn-group-lg', =>
+            @button class: 'btn selected', 'Raw'
 
-            @textarea class: "field #{rest_form.payload.split('.')[1]}", rows: 7
+          @textarea class: "field #{rest_form.payload.split('.')[1]}", rows: 7
 
       # Result
       @div class: 'rest-client-result-container padded', =>
@@ -183,9 +177,6 @@ class RestClientView extends ScrollView
 
     @on 'click', rest_form.result_link, => @toggleResult(rest_form.result)
     @on 'click', rest_form.result_headers_link, => @toggleResult(rest_form.result_headers)
-
-    @on 'click', rest_form.headers_header, => @toggleSection(rest_form.headers_body)
-    @on 'click', rest_form.payload_header, => @toggleSection(rest_form.payload_body)
 
     $('body').on 'click', rest_form.request_link, @loadRequest
     $('body').on 'click', rest_form.request_link_remove, @removeSavedRequest
@@ -343,17 +334,6 @@ class RestClientView extends ScrollView
     $target = $(target)
     $target.siblings('pre').hide()
     $target.show()
-
-  toggleSection: (target) ->
-    header = $(target).parent().children('h5')
-    headerText = header.text()
-
-    if headerText.indexOf('…') < 0
-      header.text("#{headerText} …")
-    else
-      header.text("#{headerText.slice(0, headerText.length - 2)}")
-
-    $(target).toggle()
 
   addRequestsInView: (target, requests) ->
     if not requests?

--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -28,8 +28,10 @@ rest_form =
   method_other_field: '.rest-client-method-other-field',
   headers: '.rest-client-headers',
   headers_header: '.rest-client-headers-header',
+  headers_body: '.rest-client-headers-body',
   payload: '.rest-client-payload',
   payload_header: '.rest-client-payload-header',
+  payload_body: '.rest-client-payload-body',
   encode_payload: '.rest-client-encodepayload',
   decode_payload: '.rest-client-decodepayload',
   clear_btn: '.rest-client-clear',
@@ -94,27 +96,29 @@ class RestClientView extends ScrollView
         @div class: 'rest-client-headers-container', =>
           @h5 class: "#{rest_form.headers_header.split('.')[1]}", 'Headers'
 
-          @div class: 'btn-group btn-group-lg', =>
-            @button class: 'btn selected', 'Raw'
+          @div class: "#{rest_form.headers_body.split('.')[1]}", =>
+            @div class: 'btn-group btn-group-lg', =>
+              @button class: 'btn selected', 'Raw'
 
-          @textarea class: "field #{rest_form.headers.split('.')[1]}", rows: 7
-          @strong 'Strict SSL'
-          @input type: 'checkbox', class: "field #{rest_form.strict_ssl.split('.')[1]}", checked: true
+            @textarea class: "field #{rest_form.headers.split('.')[1]}", rows: 7
+            @strong 'Strict SSL'
+            @input type: 'checkbox', class: "field #{rest_form.strict_ssl.split('.')[1]}", checked: true
 
-          @strong null, "Proxy server"
-          @input type: 'text', class: "field #{rest_form.proxy_server.split('.')[1]}"
+            @strong null, "Proxy server"
+            @input type: 'text', class: "field #{rest_form.proxy_server.split('.')[1]}"
 
         # Payload
         @div class: 'rest-client-payload-container', =>
           @h5 class: "#{rest_form.payload_header.split('.')[1]}", 'Payload'
 
-          @div class: "text-info lnk float-right #{rest_form.decode_payload.split('.')[1]}", 'Decode payload '
-          @div class: "buffer float-right", '|'
-          @div class: "text-info lnk float-right #{rest_form.encode_payload.split('.')[1]}", 'Encode payload'
-          @div class: 'btn-group btn-group-lg', =>
-            @button class: 'btn selected', 'Raw'
+          @div class: "#{rest_form.payload_body.split('.')[1]}", =>
+            @div class: "text-info lnk float-right #{rest_form.decode_payload.split('.')[1]}", 'Decode payload '
+            @div class: "buffer float-right", '|'
+            @div class: "text-info lnk float-right #{rest_form.encode_payload.split('.')[1]}", 'Encode payload'
+            @div class: 'btn-group btn-group-lg', =>
+              @button class: 'btn selected', 'Raw'
 
-          @textarea class: "field #{rest_form.payload.split('.')[1]}", rows: 7
+            @textarea class: "field #{rest_form.payload.split('.')[1]}", rows: 7
 
       # Result
       @div class: 'rest-client-result-container padded', =>

--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -91,7 +91,7 @@ class RestClientView extends ScrollView
         # Headers
         @div class: 'rest-client-headers-container', =>
           @div class: 'rest-client-headers-header', =>
-            @h5 'Headers'
+            @h5 class: 'header-expanded', 'Headers'
 
           @div class: 'rest-client-headers-body', =>
             @div class: 'btn-group btn-group-lg', =>
@@ -107,7 +107,7 @@ class RestClientView extends ScrollView
         # Payload
         @div class: 'rest-client-payload-container', =>
           @div class: 'rest-client-payload-header', =>
-            @h5 'Payload'
+            @h5 class: 'header-expanded', 'Payload'
 
           @div class: 'rest-client-payload-body', =>
             @div class: "text-info lnk float-right #{rest_form.decode_payload.split('.')[1]}", 'Decode payload '
@@ -185,15 +185,13 @@ class RestClientView extends ScrollView
     $('body').on 'click', rest_form.request_link, @loadRequest
     $('body').on 'click', rest_form.request_link_remove, @removeSavedRequest
 
-    @on 'click', '.rest-client-headers-header', => @toggleHeaders()
-    @on 'click', '.rest-client-payload-header', => @togglePayload()
+    @on 'click', '.rest-client-headers-header', => @toggleBody('.rest-client-headers-body')
+    @on 'click', '.rest-client-payload-header', => @toggleBody('.rest-client-payload-body')
 
-  toggleHeaders: ->
-    body = $('.rest-client-headers-body')
-    body.toggle()
-
-  togglePayload: ->
-    body = $('.rest-client-payload-body')
+  toggleBody: (body) ->
+    header = $('.rest-client-headers-header > h5')
+    body = $(body)
+    header.toggleClass(c) for c in ['header-expanded', 'header-collapsed']
     body.toggle()
 
   openInEditor: ->

--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -184,6 +184,9 @@ class RestClientView extends ScrollView
     @on 'click', rest_form.result_link, => @toggleResult(rest_form.result)
     @on 'click', rest_form.result_headers_link, => @toggleResult(rest_form.result_headers)
 
+    @on 'click', rest_form.headers_header, => @toggleSection(rest_form.headers_body)
+    @on 'click', rest_form.payload_header, => @toggleSection(rest_form.payload_body)
+
     $('body').on 'click', rest_form.request_link, @loadRequest
     $('body').on 'click', rest_form.request_link_remove, @removeSavedRequest
 
@@ -340,6 +343,9 @@ class RestClientView extends ScrollView
     $target = $(target)
     $target.siblings('pre').hide()
     $target.show()
+
+  toggleSection: (target) ->
+    $(target).toggle()
 
   addRequestsInView: (target, requests) ->
     if not requests?

--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -91,10 +91,7 @@ class RestClientView extends ScrollView
         # Headers
         @div class: 'rest-client-headers-container', =>
           @div class: 'rest-client-headers-header', =>
-            @h5 =>
-              @text 'Headers'
-              @span class: 'ellipsis hidden', =>
-                @raw ' &hellip;'
+            @h5 'Headers'
 
           @div class: 'rest-client-headers-body', =>
             @div class: 'btn-group btn-group-lg', =>
@@ -110,10 +107,7 @@ class RestClientView extends ScrollView
         # Payload
         @div class: 'rest-client-payload-container', =>
           @div class: 'rest-client-payload-header', =>
-            @h5 =>
-              @text 'Payload'
-              @span class: 'ellipsis hidden', =>
-                @raw ' &hellip;'
+            @h5 'Payload'
 
           @div class: 'rest-client-payload-body', =>
             @div class: "text-info lnk float-right #{rest_form.decode_payload.split('.')[1]}", 'Decode payload '
@@ -196,15 +190,11 @@ class RestClientView extends ScrollView
 
   toggleHeaders: ->
     body = $('.rest-client-headers-body')
-    ellipsis = $('.rest-client-headers-header .ellipsis')
     body.toggle()
-    ellipsis.toggleClass('hidden')
 
   togglePayload: ->
     body = $('.rest-client-payload-body')
-    ellipsis = $('.rest-client-payload-header .ellipsis')
     body.toggle()
-    ellipsis.toggleClass('hidden')
 
   openInEditor: ->
     textResult = $(rest_form.result).text()

--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -185,11 +185,11 @@ class RestClientView extends ScrollView
     $('body').on 'click', rest_form.request_link, @loadRequest
     $('body').on 'click', rest_form.request_link_remove, @removeSavedRequest
 
-    @on 'click', '.rest-client-headers-header', => @toggleBody('.rest-client-headers-body')
-    @on 'click', '.rest-client-payload-header', => @toggleBody('.rest-client-payload-body')
+    @on 'click', '.rest-client-headers-header', => @toggleBody('.rest-client-headers-header > h5', '.rest-client-headers-body')
+    @on 'click', '.rest-client-payload-header', => @toggleBody('.rest-client-payload-header > h5', '.rest-client-payload-body')
 
-  toggleBody: (body) ->
-    header = $('.rest-client-headers-header > h5')
+  toggleBody: (header, body) ->
+    header = $(header)
     body = $(body)
     header.toggleClass(c) for c in ['header-expanded', 'header-collapsed']
     body.toggle()

--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -345,6 +345,14 @@ class RestClientView extends ScrollView
     $target.show()
 
   toggleSection: (target) ->
+    header = $(target).parent().children('h5')
+    headerText = header.text()
+
+    if headerText.indexOf('…') < 0
+      header.text("#{headerText} …")
+    else
+      header.text("#{headerText.slice(0, headerText.length - 2)}")
+
     $(target).toggle()
 
   addRequestsInView: (target, requests) ->

--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -27,7 +27,9 @@ rest_form =
   method: '.rest-client-method',
   method_other_field: '.rest-client-method-other-field',
   headers: '.rest-client-headers',
+  headers_header: '.rest-client-headers-header',
   payload: '.rest-client-payload',
+  payload_header: '.rest-client-payload-header',
   encode_payload: '.rest-client-encodepayload',
   decode_payload: '.rest-client-decodepayload',
   clear_btn: '.rest-client-clear',
@@ -90,7 +92,7 @@ class RestClientView extends ScrollView
 
         # Headers
         @div class: 'rest-client-headers-container', =>
-          @h5 'Headers'
+          @h5 class: "#{rest_form.headers_header.split('.')[1]}", 'Headers'
 
           @div class: 'btn-group btn-group-lg', =>
             @button class: 'btn selected', 'Raw'
@@ -104,7 +106,7 @@ class RestClientView extends ScrollView
 
         # Payload
         @div class: 'rest-client-payload-container', =>
-          @h5 'Payload'
+          @h5 class: "#{rest_form.payload_header.split('.')[1]}", 'Payload'
 
           @div class: "text-info lnk float-right #{rest_form.decode_payload.split('.')[1]}", 'Decode payload '
           @div class: "buffer float-right", '|'

--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -90,29 +90,39 @@ class RestClientView extends ScrollView
 
         # Headers
         @div class: 'rest-client-headers-container', =>
-          @h5 'Headers'
+          @div class: 'rest-client-headers-header', =>
+            @h5 =>
+              @text 'Headers'
+              @span class: 'ellipsis hidden', =>
+                @raw ' &hellip;'
 
-          @div class: 'btn-group btn-group-lg', =>
-            @button class: 'btn selected', 'Raw'
+          @div class: 'rest-client-headers-body', =>
+            @div class: 'btn-group btn-group-lg', =>
+              @button class: 'btn selected', 'Raw'
 
-          @textarea class: "field #{rest_form.headers.split('.')[1]}", rows: 7
-          @strong 'Strict SSL'
-          @input type: 'checkbox', class: "field #{rest_form.strict_ssl.split('.')[1]}", checked: true
+            @textarea class: "field #{rest_form.headers.split('.')[1]}", rows: 7
+            @strong 'Strict SSL'
+            @input type: 'checkbox', class: "field #{rest_form.strict_ssl.split('.')[1]}", checked: true
 
-          @strong null, "Proxy server"
-          @input type: 'text', class: "field #{rest_form.proxy_server.split('.')[1]}"
+            @strong null, "Proxy server"
+            @input type: 'text', class: "field #{rest_form.proxy_server.split('.')[1]}"
 
         # Payload
         @div class: 'rest-client-payload-container', =>
-          @h5 'Payload'
+          @div class: 'rest-client-payload-header', =>
+            @h5 =>
+              @text 'Payload'
+              @span class: 'ellipsis hidden', =>
+                @raw ' &hellip;'
 
-          @div class: "text-info lnk float-right #{rest_form.decode_payload.split('.')[1]}", 'Decode payload '
-          @div class: "buffer float-right", '|'
-          @div class: "text-info lnk float-right #{rest_form.encode_payload.split('.')[1]}", 'Encode payload'
-          @div class: 'btn-group btn-group-lg', =>
-            @button class: 'btn selected', 'Raw'
+          @div class: 'rest-client-payload-body', =>
+            @div class: "text-info lnk float-right #{rest_form.decode_payload.split('.')[1]}", 'Decode payload '
+            @div class: "buffer float-right", '|'
+            @div class: "text-info lnk float-right #{rest_form.encode_payload.split('.')[1]}", 'Encode payload'
+            @div class: 'btn-group btn-group-lg', =>
+              @button class: 'btn selected', 'Raw'
 
-          @textarea class: "field #{rest_form.payload.split('.')[1]}", rows: 7
+            @textarea class: "field #{rest_form.payload.split('.')[1]}", rows: 7
 
       # Result
       @div class: 'rest-client-result-container padded', =>
@@ -180,6 +190,21 @@ class RestClientView extends ScrollView
 
     $('body').on 'click', rest_form.request_link, @loadRequest
     $('body').on 'click', rest_form.request_link_remove, @removeSavedRequest
+
+    @on 'click', '.rest-client-headers-header', => @toggleHeaders()
+    @on 'click', '.rest-client-payload-header', => @togglePayload()
+
+  toggleHeaders: ->
+    body = $('.rest-client-headers-body')
+    ellipsis = $('.rest-client-headers-header .ellipsis')
+    body.toggle()
+    ellipsis.toggleClass('hidden')
+
+  togglePayload: ->
+    body = $('.rest-client-payload-body')
+    ellipsis = $('.rest-client-payload-header .ellipsis')
+    body.toggle()
+    ellipsis.toggleClass('hidden')
 
   openInEditor: ->
     textResult = $(rest_form.result).text()
@@ -337,7 +362,7 @@ class RestClientView extends ScrollView
 
   addRequestsInView: (target, requests) ->
     if not requests?
-        return
+      return
 
     for request in requests
       @addRequestItem(target, request)

--- a/styles/rest-client.less
+++ b/styles/rest-client.less
@@ -105,7 +105,11 @@ input[type='text'], textarea {
   padding-left: 10px;
 }
 
-.rest-client-headers-header:hover, .rest-client-payload-header:hover {
+.rest-client-header {
+  color: @text-color-info;
+}
+
+.rest-client-header:hover {
   cursor: pointer;
 }
 

--- a/styles/rest-client.less
+++ b/styles/rest-client.less
@@ -108,3 +108,15 @@ input[type='text'], textarea {
 .rest-client-headers-header:hover, .rest-client-payload-header:hover {
   cursor: pointer;
 }
+
+.header-expanded::before {
+  content: '↓ ';
+}
+
+.header-collapsed::before {
+  content: '→ ';
+}
+
+.header-collapsed::after {
+  content: ' …'
+}

--- a/styles/rest-client.less
+++ b/styles/rest-client.less
@@ -105,10 +105,6 @@ input[type='text'], textarea {
   padding-left: 10px;
 }
 
-.hidden {
-  display: none;
-}
-
 .rest-client-headers-header:hover, .rest-client-payload-header:hover {
   cursor: pointer;
 }

--- a/styles/rest-client.less
+++ b/styles/rest-client.less
@@ -106,3 +106,7 @@ input[type='text'], textarea {
 .rest-client-request-link-remove {
   padding-left: 10px;
 }
+
+.hidden {
+  display: none;
+}

--- a/styles/rest-client.less
+++ b/styles/rest-client.less
@@ -42,8 +42,6 @@
   }
 }
 
-
-
 .rest-client-url {
   width: 100%;
   font-size: 15px;
@@ -109,4 +107,8 @@ input[type='text'], textarea {
 
 .hidden {
   display: none;
+}
+
+.rest-client-headers-header:hover, .rest-client-payload-header:hover {
+  cursor: pointer;
 }


### PR DESCRIPTION
The "Headers" and "Payload" text can be clicked to hide the bodies of the respective sections. For example, clicking "Headers" will change the text to "Headers ..." and hide all related elements. This can be useful for people who want more visibility in the Result area when it's at the bottom but don't use the Headers and/or Payload sections.