### PR TITLE
File extensions

### DIFF
--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -126,11 +126,11 @@ class RestClientView extends ScrollView
         @a class: "#{rest_form.result_headers_link.split('.')[1]}", 'Headers'
         @span ' | '
         @span class: "#{rest_form.status.split('.')[1]}"
+        @span class: "text-info lnk #{rest_form.open_in_editor.split('.')[1]}", 'Open in separate editor'
 
         @span class: "#{rest_form.loading.split('.')[1]} loading loading-spinner-small inline-block", style: 'display: none;'
         @pre class: "#{rest_form.result_headers.split('.')[1]}", ""
         @pre class: "#{rest_form.result.split('.')[1]}", "#{RestClientResponse.DEFAULT_RESPONSE}"
-        @div class: "text-info lnk #{rest_form.open_in_editor.split('.')[1]}", 'Open in separate editor'
 
   initialize: ->
     @COLLECTIONS_PATH = "#{PACKAGE_PATH}/collections.json"

--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -196,10 +196,12 @@ class RestClientView extends ScrollView
 
   openInEditor: ->
     textResult = $(rest_form.result).text()
-    extension = mime.extension(@lastResponse.headers['content-type']);
-    file_name = "#{@lastRequest.method} #{@lastRequest.url}#{'.' + extension if extension}"
-    editor = new RestClientEditor(textResult, file_name)
+    editor = new RestClientEditor(textResult, @constructFileName())
     editor.open()
+
+  constructFileName: ->
+    extension = mime.extension(@lastResponse.headers['content-type'])
+    "#{@lastRequest.method} #{@lastRequest.url}#{'.' + extension if extension}"
 
   encodePayload: ->
     $(rest_form.payload).val(
@@ -286,6 +288,7 @@ class RestClientView extends ScrollView
     else
       @showErrorResponse(DEFAULT_NORESPONSE)
       result = error
+
     $(rest_form.result).text(result)
     $(rest_form.result_headers).text(headers).hide()
     @emitter.emit RestClientEvent.REQUEST_FINISHED, response

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "atom-space-pen-views": "^2.0.3",
+    "mime-types": "^2.1.12",
     "request": "*"
   }
 }

--- a/spec/rest-client-view-spec.coffee
+++ b/spec/rest-client-view-spec.coffee
@@ -9,3 +9,9 @@ describe "RestClientView test", ->
   describe "View", ->
     it "the view is loaded", ->
       expect(restClient.find('.rest-client-send')).toExist()
+
+  describe "constructFileName", ->
+    it "contains the url, the method and an extension inferred from the response content-type", ->
+      restClient.setLastRequest { url: "http://example.com", method: "GET" }
+      restClient.setLastResponse { headers: { "content-type": "application/json" } }
+      expect(restClient.constructFileName()).toEqual "GET http://example.com.json"

--- a/styles/rest-client.less
+++ b/styles/rest-client.less
@@ -30,6 +30,10 @@
   float: right;
   width: 50%;
 
+  .rest-client-open-in-editor {
+    float: right;
+  }
+
   @media only screen and (min-width: 800px) {
     padding-top: 0;
   }


### PR DESCRIPTION
Improves the *Open in separate editor* feature.

This adds an ability of inferring the appropriate file extension basing on the response Content-Type. The most important point is that this allows Atom to highlight the file nicely and makes working with it easier. (Quiet related with #37.)

I also moved the option to the top as it's really frustrating to scroll down when the response is huge. Here's how it looks now:

![screenshot from 2016-10-10 19-39-59](https://cloud.githubusercontent.com/assets/17034772/19245441/66d05666-8f21-11e6-84a8-2acdf87afde1.png)

![screenshot from 2016-10-10 19-40-12](https://cloud.githubusercontent.com/assets/17034772/19245443/6a579e48-8f21-11e6-9685-88bf6c48583a.png)
