### PR TITLE
Issue #83 fix: Ignore request payload when using HEAD method

### DIFF
--- a/lib/rest-client-view.coffee
+++ b/lib/rest-client-view.coffee
@@ -250,6 +250,9 @@ class RestClientView extends ScrollView
       atom.notifications.addError PAYLOAD_JSON_ERROR_MESSAGE
       return
 
+    if request_options.method == "HEAD"
+      request_options.body = ""
+
     if request_options.url
       @emitter.emit RestClientEvent.NEW_REQUEST, request_options
       RestClientHttp.send(request_options, @onResponse)


### PR DESCRIPTION
Fix to the issue reported by https://github.com/ddavison/rest-client/issues/83